### PR TITLE
Fixed issue with filter and arrays with objecs

### DIFF
--- a/src/tags/filter.js
+++ b/src/tags/filter.js
@@ -39,7 +39,8 @@ module.exports =
             let i = 0;
 
             for (const item of array) {
-                if (processed[item]) continue;
+                let stringifiedItem = typeof item === 'object' ? JSON.stringify(item) : null;
+                if (processed[stringifiedItem || item]) continue;
                 if (await bbengine.safeLoopIteration(context)) {
                     return Builder.errors.maxSafeLoops(subtag, context);
                 };
@@ -50,8 +51,9 @@ module.exports =
                     if (context.state.return)
                         break;
                     if (res) {
-                        processed[item] = true;
-                        result.push(...array.filter(e => e === item));
+                        processed[stringifiedItem || item] = true;
+                        //If item 'e' is an object, it stringifies it for comparison. Otherwise it will always return false
+                        result.push(...array.filter(e => typeof e === 'object' ? JSON.stringify(e) === stringifiedItem : e === item));
                     }
                     if (i++ % 1000 === 0)
                         await this.sleep();


### PR DESCRIPTION
Fixes bug report [595](https://airtable.com/shrEUdEv4NM04Wi7O/tblyFuWE6fEAbaOfo/viwDg5WovcwMA9NIL/recTKg4fJgYCobLIb?blocks=bipip3uBZFRPcSy3C)

To avoid storing objects in the `processed` object as `[object Object]`, they need to be stringified when checking if it's processed, when storing them and when pushing equal objects to `result`.